### PR TITLE
Don't expose build time dependencies

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -7,7 +7,8 @@
         com.vladsch.flexmark/flexmark-ext-footnotes {:mvn/version "0.62.2"}
         com.vladsch.flexmark/flexmark-ext-gfm-strikethrough {:mvn/version "0.62.2"}
         com.vladsch.flexmark/flexmark-ext-gfm-tasklist {:mvn/version "0.62.2"}
-        com.vladsch.flexmark/flexmark-test-util {:mvn/version "0.62.2"}
+        com.vladsch.flexmark/flexmark-test-util {:mvn/version "0.62.2"
+                                                 :exclusions [junit/junit]}
         com.vladsch.flexmark/flexmark-ext-gitlab {:mvn/version "0.62.2"}
         hickory/hickory {:mvn/version "0.7.1"}
         cljs-bean/cljs-bean {:mvn/version "1.7.0"}

--- a/deps.edn
+++ b/deps.edn
@@ -12,10 +12,11 @@
         com.vladsch.flexmark/flexmark-ext-gitlab {:mvn/version "0.62.2"}
         hickory/hickory {:mvn/version "0.7.1"}
         cljs-bean/cljs-bean {:mvn/version "1.7.0"}
-        thheller/shadow-cljs {:mvn/version "2.15.9"}}
+        }
 
  :aliases {:test-cljs {:extra-paths ["test"]
-                       :main-opts ["-m" "shadow.cljs.devtools.cli" "release" "test"]}
+                       :main-opts ["-m" "shadow.cljs.devtools.cli" "release" "test"]
+                        :extra-deps {thheller/shadow-cljs {:mvn/version "2.15.9"}}}
            :test-clj {:extra-paths ["test"]
                       :extra-deps {lambdaisland/kaocha {:mvn/version "1.0.887"}
                                    lambdaisland/kaocha-junit-xml {:mvn/version "0.0.76"}


### PR DESCRIPTION
Suggested fixes for https://github.com/kiranshila/cybermonday/issues/22

Note I have not yet generated a build for these because the github actions / build process fails to perform the code coverage checks in my fork.

So there may be some small tweaks needed.

