### PR TITLE
Fixes #26 CVE-2017-18640

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -2,6 +2,7 @@
 
  :deps {org.clojure/clojure {:mvn/version "1.10.3"}
         io.forward/yaml {:mvn/version "1.0.11"}
+        org.yaml/snakeyaml {:mvn/version "1.30"} ;; bump transitive dep of io.forward/yaml to avoid CVE-2017-18640
         com.vladsch.flexmark/flexmark {:mvn/version "0.62.2"}
         com.vladsch.flexmark/flexmark-ext-tables {:mvn/version "0.62.2"}
         com.vladsch.flexmark/flexmark-ext-footnotes {:mvn/version "0.62.2"}


### PR DESCRIPTION
With this PR nvd reports: 

```
$ clojure -Tnvd nvd.task/check :classpath '"'"$(clojure -Spath)"'"'

+--------------------------------------------------+-------------------------------+
| dependency                                       | status                        |
+--------------------------------------------------+-------------------------------+
| google-closure-library-0.0-20160609-f42b4a24.jar | CVE-2020-8910                 |
| guava-19.0.jar                                   | CVE-2018-10237, CVE-2020-8908 |
| jsoup-1.9.2.jar                                  | CVE-2021-37714                |
+--------------------------------------------------+-------------------------------+

4 vulnerabilities detected. Severity: MEDIUM
```

Prior to this PR it reports: 

```
+--------------------------------------------------+-------------------------------+
| dependency                                       | status                        |
+--------------------------------------------------+-------------------------------+
| google-closure-library-0.0-20160609-f42b4a24.jar | CVE-2020-8910                 |
| guava-19.0.jar                                   | CVE-2018-10237, CVE-2020-8908 |
| jsoup-1.9.2.jar                                  | CVE-2021-37714                |
| snakeyaml-1.25.jar                               | CVE-2017-18640                |
+--------------------------------------------------+-------------------------------+

5 vulnerabilities detected. Severity: MEDIUM
```

I will investigate and attempt patches for the remaining reported CVEs though suspect the most important to fix will be bumping the jsoup dependency.