### PR TITLE
Bump jsoup dep as workaround fix for CVE-2021-37714

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -12,7 +12,14 @@
                                                  :exclusions [junit/junit]}
         com.vladsch.flexmark/flexmark-ext-gitlab {:mvn/version "0.62.2"}
         hickory/hickory {:mvn/version "0.7.1"}
-        cljs-bean/cljs-bean {:mvn/version "1.8.0"}}
+
+        ;; Fix for jsoup CVE-2021-37714. Jsoup is a transitive dep of
+        ;; hickory. If hickory bumps its version we can remove the dep
+        ;; here.
+        org.jsoup/jsoup {:mvn/version "1.14.3"}
+
+        cljs-bean/cljs-bean {:mvn/version "1.8.0"}
+        }
 
  :aliases {:test-cljs {:extra-paths ["test"]
                        :extra-deps {thheller/shadow-cljs {:mvn/version "2.16.12"}}


### PR DESCRIPTION
Fix #31 