### PR TITLE
Add support for Flexmark TOC extension (#63)

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -11,6 +11,7 @@
         com.vladsch.flexmark/flexmark-test-util {:mvn/version "0.64.0"
                                                  :exclusions [junit/junit]}
         com.vladsch.flexmark/flexmark-ext-gitlab {:mvn/version "0.64.0"}
+        com.vladsch.flexmark/flexmark-ext-toc {:mvn/version "0.64.0"}
         org.clj-commons/hickory {:mvn/version "0.7.3"}
         cljs-bean/cljs-bean {:mvn/version "1.9.0"}}
 

--- a/src/cybermonday/parser.clj
+++ b/src/cybermonday/parser.clj
@@ -19,14 +19,16 @@
    (com.vladsch.flexmark.ext.gfm.strikethrough StrikethroughExtension Strikethrough)
    (com.vladsch.flexmark.ext.gfm.tasklist TaskListExtension TaskListItem)
    (com.vladsch.flexmark.test.util AstCollectingVisitor)
-   (com.vladsch.flexmark.ext.gitlab GitLabExtension GitLabInlineMath)))
+   (com.vladsch.flexmark.ext.gitlab GitLabExtension GitLabInlineMath)
+   (com.vladsch.flexmark.ext.toc TocExtension TocBlock)))
 
 (def options
   "The default options for the Flexmark parser
   There shouldn't be a reason to change this"
   (.. (MutableDataSet.)
       (set Parser/EXTENSIONS
-           [(TablesExtension/create)
+           [(TocExtension/create)
+            (TablesExtension/create)
             (FootnoteExtension/create)
             (StrikethroughExtension/create)
             (TaskListExtension/create)
@@ -183,6 +185,9 @@
   TableSeparator
   (to-hiccup [this _]
     nil)
+  TocBlock
+  (to-hiccup [this _]
+    [:markdown/table-of-contents {:style (str (.getStyle this))}])
   nil
   (to-hiccup [this _]
     nil))

--- a/test/cybermonday/core_test.cljc
+++ b/test/cybermonday/core_test.cljc
@@ -108,7 +108,10 @@
                   [:markdown/reference {:label "foo *bar*"
                                         :title "train & tracks"
                                         :url "train.jpg"}]]
-                 (ir/md-to-ir "![foo *bar*][]\n\n[foo *bar*]: train.jpg \"train & tracks\""))))))
+                 (ir/md-to-ir "![foo *bar*][]\n\n[foo *bar*]: train.jpg \"train & tracks\""))))
+    #?(:clj (t/testing "Table of Contents"
+              (t/is (= [:div {} [:markdown/table-of-contents {:style ""}]] (ir/md-to-ir "[TOC]")))
+              (t/is (= [:div {} [:markdown/table-of-contents {:style "levels=1-3"}]] (ir/md-to-ir "[TOC levels=1-3]")))))))
 
 (t/deftest html-lowering
   (t/testing "Parsing to HTML"


### PR DESCRIPTION
This patch adds a new dependency on flexmark-ext-toc and adds the extension to the Flexmark parser. This enables a table of contents node to be included in the markdown IR by including a line of `[TOC]` in the markdown content. Optionally a list of heading levels to be included can be specified like so: `[TOC levels=1-3,5]`. This new IR node is called :markdown/table-of-contents.

The patch also includes a translation from this node into Hiccup. This lower function is unique because it requires the full IR representation and thus requires two arguments. It analyzes the IR's headings and creates a nested unordered-list which link to the headings via their `id` values which were already created in the heading lower function.

Fixes #63 